### PR TITLE
Fix name of function in if condition

### DIFF
--- a/src/windows/KeyboardProxy.js
+++ b/src/windows/KeyboardProxy.js
@@ -29,7 +29,7 @@ module.exports.show = function () {
 };
 
 module.exports.close = function () {
-    if (typeof inputPane.tryShow === 'function') {
+    if (typeof inputPane.tryHide === 'function') {
         inputPane.tryHide();
     }
 };


### PR DESCRIPTION
Function name should be mapped to the related function which is called afterwards.