### PR TITLE
Make disableScroll work with iPhone X

### DIFF
--- a/src/ios/IonicKeyboard.m
+++ b/src/ios/IonicKeyboard.m
@@ -119,7 +119,12 @@
 /* ------------------------------------------------------------- */
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    [scrollView setContentOffset: CGPointZero];
+    if (@available(iOS 11.0, *)) {
+        [scrollView setContentOffset: CGPointMake(0.0, self.webView.safeAreaInsets.top * -1)];
+    }
+    else {
+        [scrollView setContentOffset: CGPointZero];
+    }
 }
 
 /* ------------------------------------------------------------- */


### PR DESCRIPTION
This prevents the scrollview from getting stuck at the top of the screen when disableScroll is enabled on the iPhone X. 
